### PR TITLE
more reduction tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,10 @@ jobs:
             python=${{matrix.python-version}}
             conda
 
+      - name: Install nightly xarray
+        run: |
+          python -m pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple xarray
+
       - name: Install xarray-array-testing
         run: |
           python -m pip install --no-deps -e .

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -9,4 +9,7 @@ dependencies:
   - pytest-cov
   - hypothesis
   - xarray
-  - numpy<2.1
+  - numpy
+  - pip
+  - pip:
+      - -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple xarray

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -12,5 +12,5 @@ dependencies:
   - numpy
   - pip
   - pip:
-      - --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
       - xarray

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -9,4 +9,4 @@ dependencies:
   - pytest-cov
   - hypothesis
   - xarray
-  - numpy
+  - numpy<2.1

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -12,7 +12,5 @@ dependencies:
   - numpy
   - pip
   - pip:
-      - --pre
-      - -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-      - --extra-index-url https://pypi.org/simple
+      - --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
       - xarray

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -10,7 +10,3 @@ dependencies:
   - hypothesis
   - xarray
   - numpy
-  - pip
-  - pip:
-      - --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
-      - xarray

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -12,4 +12,7 @@ dependencies:
   - numpy
   - pip
   - pip:
-      - -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple xarray
+      - --pre
+      - -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+      - --extra-index-url https://pypi.org/simple
+      - xarray

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -25,3 +25,17 @@ class ReductionTests(DuckArrayTestMixin):
             expected = getattr(self.xp, op)(variable.data)
 
         self.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize("op", ["all", "any"])
+    @given(st.data())
+    def test_variable_boolean_reduce(self, op, data):
+        variable = data.draw(xrst.variables(array_strategy_fn=self.array_strategy_fn))
+
+        with self.expected_errors(op, variable=variable):
+            # compute using xr.Variable.<OP>()
+            actual = getattr(variable, op)().data
+            # compute using xp.<OP>(array)
+            expected = getattr(self.xp, op)(variable.data)
+
+        assert isinstance(actual, self.array_type)
+        self.assert_equal(actual, expected)

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -68,7 +68,16 @@ class ReductionTests(DuckArrayTestMixin):
         assert isinstance(actual, self.array_type)
         self.assert_equal(actual, expected)
 
-    @pytest.mark.parametrize("op", ["cumsum", "cumprod"])
+    @pytest.mark.parametrize(
+        "op",
+        [
+            "cumsum",
+            pytest.param(
+                "cumprod",
+                marks=pytest.mark.skip(reason="not yet included in the array api"),
+            ),
+        ],
+    )
     @given(st.data())
     def test_variable_cumulative_reduce(self, op, data):
         array_api_names = {"cumsum": "cumulative_sum", "cumprod": "cumulative_prod"}

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -53,3 +53,17 @@ class ReductionTests(DuckArrayTestMixin):
 
         assert isinstance(actual, self.array_type)
         self.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize("op", ["argmax", "argmin"])
+    @given(st.data())
+    def test_variable_order_reduce_index(self, op, data):
+        variable = data.draw(xrst.variables(array_strategy_fn=self.array_strategy_fn))
+
+        with self.expected_errors(op, variable=variable):
+            # compute using xr.Variable.<OP>()
+            actual = getattr(variable, op)().data
+            # compute using xp.<OP>(array)
+            expected = getattr(self.xp, op)(variable.data)
+
+        assert isinstance(actual, self.array_type)
+        self.assert_equal(actual, expected)

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -25,6 +25,7 @@ class ReductionTests(DuckArrayTestMixin):
             # compute using xp.<OP>(array)
             expected = getattr(self.xp, op)(variable.data)
 
+        assert isinstance(actual, self.array_type), f"wrong type: {type(actual)}"
         self.assert_equal(actual, expected)
 
     @pytest.mark.parametrize("op", ["all", "any"])
@@ -38,7 +39,7 @@ class ReductionTests(DuckArrayTestMixin):
             # compute using xp.<OP>(array)
             expected = getattr(self.xp, op)(variable.data)
 
-        assert isinstance(actual, self.array_type)
+        assert isinstance(actual, self.array_type), f"wrong type: {type(actual)}"
         self.assert_equal(actual, expected)
 
     @pytest.mark.parametrize("op", ["max", "min"])
@@ -52,7 +53,7 @@ class ReductionTests(DuckArrayTestMixin):
             # compute using xp.<OP>(array)
             expected = getattr(self.xp, op)(variable.data)
 
-        assert isinstance(actual, self.array_type)
+        assert isinstance(actual, self.array_type), f"wrong type: {type(actual)}"
         self.assert_equal(actual, expected)
 
     @pytest.mark.parametrize("op", ["argmax", "argmin"])
@@ -95,5 +96,5 @@ class ReductionTests(DuckArrayTestMixin):
             for axis in range(variable.ndim):
                 expected = getattr(self.xp, array_api_names[op])(expected, axis=axis)
 
-        assert isinstance(actual, self.array_type)
+        assert isinstance(actual, self.array_type), f"wrong type: {type(actual)}"
         self.assert_equal(actual, expected)

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -87,7 +87,10 @@ class ReductionTests(DuckArrayTestMixin):
             # compute using xr.Variable.<OP>()
             actual = getattr(variable, op)().data
             # compute using xp.<OP>(array)
-            expected = getattr(self.xp, array_api_names[op])(variable.data)
+            # Variable implements n-d cumulative ops by iterating over dims
+            expected = variable.data
+            for axis in range(variable.ndim):
+                expected = getattr(self.xp, array_api_names[op])(expected, axis=axis)
 
         assert isinstance(actual, self.array_type)
         self.assert_equal(actual, expected)

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -67,3 +67,18 @@ class ReductionTests(DuckArrayTestMixin):
 
         assert isinstance(actual, self.array_type)
         self.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize("op", ["cumsum", "cumprod"])
+    @given(st.data())
+    def test_variable_cumulative_reduce(self, op, data):
+        array_api_names = {"cumsum": "cumulative_sum", "cumprod": "cumulative_prod"}
+        variable = data.draw(xrst.variables(array_strategy_fn=self.array_strategy_fn))
+
+        with self.expected_errors(op, variable=variable):
+            # compute using xr.Variable.<OP>()
+            actual = getattr(variable, op)().data
+            # compute using xp.<OP>(array)
+            expected = getattr(self.xp, array_api_names[op])(variable.data)
+
+        assert isinstance(actual, self.array_type)
+        self.assert_equal(actual, expected)

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -39,3 +39,17 @@ class ReductionTests(DuckArrayTestMixin):
 
         assert isinstance(actual, self.array_type)
         self.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize("op", ["max", "min"])
+    @given(st.data())
+    def test_variable_order_reduce(self, op, data):
+        variable = data.draw(xrst.variables(array_strategy_fn=self.array_strategy_fn))
+
+        with self.expected_errors(op, variable=variable):
+            # compute using xr.Variable.<OP>()
+            actual = getattr(variable, op)().data
+            # compute using xp.<OP>(array)
+            expected = getattr(self.xp, op)(variable.data)
+
+        assert isinstance(actual, self.array_type)
+        self.assert_equal(actual, expected)


### PR DESCRIPTION
- [x] follow-up to #2

This adds a few more reduction (or index reduction) tests, which should cover everything `xarray` supports and which is part of the array API. `xarray` additionally provides sorting-based reductions like `quantile` and `median`, plus `rank` which I don't quite understand.