### PR TITLE
upgrade ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates once a week
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,11 @@ jobs:
       github.repository == 'xarray-contrib/xarray-array-testing'
       && (github.event_name == 'push' || github.event_name == 'pull_request')
     outputs:
-      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+      triggered: |
+        ${{
+          steps.detect-trigger.outputs.trigger-found == 'true'
+          || contains(github.event.pull_request.labels.*.name, 'skip-ci')
+        }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,9 +39,7 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     needs: detect-ci-trigger
-    if: |
-      needs.detect-ci-trigger.outputs.triggered == 'false'
-      || contains(github.event.pull_request.labels.*.name, 'skip-ci')
+    if: ! needs.detect-ci-trigger.outputs.triggered
 
     env:
       FORCE_COLOR: 3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,13 +79,17 @@ jobs:
           python -c 'import xarray_array_testing'
 
       - name: Restore cached hypothesis directory
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .hypothesis/
           key: cache-hypothesis
-          enableCrossOsArchive: true
-          save-always: true
 
       - name: Run tests
         run: |
           python -m pytest --cov=xarray_array_testing
+
+      - name: Cache hypothesis directory
+        uses: actions/cache/save@v4
+        with:
+          path: .hypothesis/
+          key: cache-hypothesis

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,10 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     needs: detect-ci-trigger
-    if: needs.detect-ci-trigger.outputs.triggered == 'false'
+    if: |
+      needs.detect-ci-trigger.outputs.triggered == 'false'
+      || contains(github.event.pull_request.labels.*.name, 'skip-ci')
+
     env:
       FORCE_COLOR: 3
       CONDA_ENV_FILE: "ci/requirements/environment.yaml"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,9 @@ jobs:
     if: |
       github.repository == 'xarray-contrib/xarray-array-testing'
       && (github.event_name == 'push' || github.event_name == 'pull_request')
+      && !contains(github.event.pull_request.labels.*.name, 'skip-ci')
     outputs:
-      triggered: |
-        ${{
-          steps.detect-trigger.outputs.trigger-found == 'true'
-          || contains(github.event.pull_request.labels.*.name, 'skip-ci')
-        }}
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +36,7 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     needs: detect-ci-trigger
-    if: ! needs.detect-ci-trigger.outputs.triggered
+    if: needs.detect-ci-trigger.outputs.triggered == 'false'
 
     env:
       FORCE_COLOR: 3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,6 @@ jobs:
           cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
           create-args: >-
             python=${{matrix.python-version}}
-            conda
 
       - name: Install nightly xarray
         run: |
@@ -74,11 +73,6 @@ jobs:
       - name: Install xarray-array-testing
         run: |
           python -m pip install --no-deps -e .
-
-      - name: Version info
-        run: |
-          conda info -a
-          conda list
 
       - name: Import xarray-array-testing
         run: |


### PR DESCRIPTION
includes:
- test on python 3.13
- allow skipping CI based on a label
- configure dependabot
- exclude bots from the auto-generated release notes