### PR TITLE
improve support for argreduction comparisons

### DIFF
--- a/xarray_array_testing/base.py
+++ b/xarray_array_testing/base.py
@@ -2,7 +2,6 @@ import abc
 from abc import ABC
 from types import ModuleType
 
-import numpy as np
 import numpy.testing as npt
 from xarray.namedarray._typing import duckarray
 
@@ -26,13 +25,14 @@ class DuckArrayTestMixin(ABC):
     def assert_equal(a, b):
         npt.assert_equal(a, b)
 
-    @staticmethod
-    def assert_dimension_indexers_equal(a, b):
+    def assert_dimension_indexers_equal(self, a, b):
         assert type(a) is type(b), f"types don't match: {type(a)} vs {type(b)}"
 
         if isinstance(a, dict):
             assert a.keys() == b.keys(), f"Different dimensions: {list(a)} vs {list(b)}"
 
-            assert all(np.equal(a[k], b[k]) for k in a), "Differing indexers"
+            assert all(
+                self.xp.all(self.xp.equal(a[k], b[k])) for k in a
+            ), "Differing indexers"
         else:
             npt.assert_equal(a, b)

--- a/xarray_array_testing/base.py
+++ b/xarray_array_testing/base.py
@@ -4,7 +4,6 @@ from types import ModuleType
 
 import numpy as np
 import numpy.testing as npt
-import xarray as xr
 from xarray.namedarray._typing import duckarray
 
 
@@ -34,15 +33,6 @@ class DuckArrayTestMixin(ABC):
         if isinstance(a, dict):
             assert a.keys() == b.keys(), f"Different dimensions: {list(a)} vs {list(b)}"
 
-            values = ((a[k], b[k]) for k in a)
-            assert all(
-                (
-                    isinstance(v1, xr.Variable)
-                    and isinstance(v2, xr.Variable)
-                    and v1.dims == v2.dims
-                    and np.equal(v1.data, v2.data)
-                )
-                for v1, v2 in values
-            ), "Differing indexers"
+            assert all(np.equal(a[k], b[k]) for k in a), "Differing indexers"
         else:
             npt.assert_equal(a, b)

--- a/xarray_array_testing/base.py
+++ b/xarray_array_testing/base.py
@@ -2,7 +2,9 @@ import abc
 from abc import ABC
 from types import ModuleType
 
+import numpy as np
 import numpy.testing as npt
+import xarray as xr
 from xarray.namedarray._typing import duckarray
 
 
@@ -24,3 +26,23 @@ class DuckArrayTestMixin(ABC):
     @staticmethod
     def assert_equal(a, b):
         npt.assert_equal(a, b)
+
+    @staticmethod
+    def assert_dimension_indexers_equal(a, b):
+        assert type(a) is type(b), f"types don't match: {type(a)} vs {type(b)}"
+
+        if isinstance(a, dict):
+            assert a.keys() == b.keys(), f"Different dimensions: {list(a)} vs {list(b)}"
+
+            values = ((a[k], b[k]) for k in a)
+            assert all(
+                (
+                    isinstance(v1, xr.Variable)
+                    and isinstance(v2, xr.Variable)
+                    and v1.dims == v2.dims
+                    and np.equal(v1.data, v2.data)
+                )
+                for v1, v2 in values
+            ), "Differing indexers"
+        else:
+            npt.assert_equal(a, b)

--- a/xarray_array_testing/reduction.py
+++ b/xarray_array_testing/reduction.py
@@ -77,9 +77,9 @@ class ReductionTests(DuckArrayTestMixin):
             else:
                 actual_ = actual.data
 
+            note(f"dim: {dim}")
             if dim is not ... and not isinstance(dim, list):
                 # compute using xp.<OP>(array)
-                note(dim)
                 axis = variable.get_axis_num(dim)
                 indices = getattr(self.xp, op)(variable.data, axis=axis)
 


### PR DESCRIPTION
The arg reduction methods in `Variable` return behave differently depending on the `dims` parameter:
- for `dim=...` or `dim=None`: return a dict containing the indices for all dims
- for `dim` as a list: return a dict containing the indices for the given dims
- for `dim` as a hashable: return a single int index for the raveled array

We thus need to construct the proper expected value to be able to check the result.